### PR TITLE
fix(web-scripts-migration): do not replace `WEB_APP_*` for phaser-template

### DIFF
--- a/packages/web-scripts-migration/index.js
+++ b/packages/web-scripts-migration/index.js
@@ -69,7 +69,10 @@ jscodeshift(
 );
 exec('git add -u');
 if (isPhaser) {
-  exec('git grep -l APP_ | xargs sed -i "" -e "s/APP_/WEB_APP_/g"');
+  // replace environment variables matching `APP_*` with `WEB_APP_*`
+  exec(
+    'git grep -l -e "APP_" --and --not -e "WEB_APP_" | xargs sed -i "" -e "/WEB_APP_/! s/APP_/WEB_APP_/g"'
+  );
   exec(
     'git grep -l WEB_APP_PHASER_SCRIPT_SRC | xargs sed -i "" -e "s/WEB_APP_PHASER_SCRIPT_SRC/WEB_APP_PHASER_SCRIPT/g"'
   );

--- a/packages/web-scripts-migration/index.js
+++ b/packages/web-scripts-migration/index.js
@@ -46,24 +46,6 @@ packageJson.scripts['test:ci'] = 'CI=true npm test -- --passWithNoTests';
 write('package.json', packageJson);
 
 /**
- * Add `.env`.
- */
-if (isPhaser) {
-  log('Adding `.env`...');
-  write(
-    '.env',
-    `# Expected environment variables.
-IMAGE_INLINE_SIZE_LIMIT=0 # Local data URIs are not supported in Phaser 3.
-
-# Custom environment variables.
-WEB_APP_HOMEPAGE=$npm_package_homepage
-WEB_APP_PHASER_SCRIPT=//cdn.jsdelivr.net/npm/phaser@$npm_package_devDependencies_phaser/dist/phaser.min.js
-WEB_APP_VERSION=$npm_package_version`
-  );
-  exec('git add .env');
-}
-
-/**
  * Add `.eslintrc.json`.
  */
 log('Adding `.eslintrc.json`...');
@@ -92,6 +74,24 @@ if (isPhaser) {
     'git grep -l WEB_APP_PHASER_SCRIPT_SRC | xargs sed -i "" -e "s/WEB_APP_PHASER_SCRIPT_SRC/WEB_APP_PHASER_SCRIPT/g"'
   );
   exec('git grep -l WEB_APP_ | xargs git add');
+}
+
+/**
+ * Add `.env` (this must happen after `s/APP_/WEB_APP_/g` is run).
+ */
+if (isPhaser) {
+  log('Adding `.env`...');
+  write(
+    '.env',
+    `# Expected environment variables.
+IMAGE_INLINE_SIZE_LIMIT=0 # Local data URIs are not supported in Phaser 3.
+
+# Custom environment variables.
+WEB_APP_HOMEPAGE=$npm_package_homepage
+WEB_APP_PHASER_SCRIPT=//cdn.jsdelivr.net/npm/phaser@$npm_package_devDependencies_phaser/dist/phaser.min.js
+WEB_APP_VERSION=$npm_package_version`
+  );
+  exec('git add .env');
 }
 
 /**


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(web-scripts-migration): do not replace `WEB_APP_*` for phaser-template

## What is the current behavior?

Running `npx web-scripts-migration --phaser` does a grep and sed for `WEB_APP_*` that leads to `WEB_WEB_APP_*`.

## What is the new behavior?

Running `npx web-scripts-migration --phaser` will exclude `WEB_APP_*` from grep and sed.