### PR TITLE
fix(web-scripts): set dependency `mini-css-extract-plugin` to ~2.4.5

### DIFF
--- a/packages/web-scripts/package.json
+++ b/packages/web-scripts/package.json
@@ -52,7 +52,7 @@
     "jest": "^27.4.3",
     "jest-resolve": "^27.4.2",
     "jest-watch-typeahead": "^1.0.0",
-    "mini-css-extract-plugin": "^2.4.5",
+    "mini-css-extract-plugin": "~2.4.5",
     "postcss": "^8.4.4",
     "postcss-flexbugs-fixes": "^5.0.2",
     "postcss-loader": "^6.2.1",


### PR DESCRIPTION
https://github.com/facebook/create-react-app/issues/11930

https://github.com/webpack-contrib/mini-css-extract-plugin/issues/896